### PR TITLE
Oppgraderer til PDFBox 3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ val jsoupVersion = "1.18.1"
 val kluentVersion = "1.72"
 val logbackVersion = "1.5.6"
 val logstashEncoderVersion = "8.0"
-val openHtmlToPdfVersion = "pdfbox2-65c2c5010f84b2daa5821971c9c68cd330463830"
+val openHtmlToPdfVersion = "1.1.21"
 val prometheusVersion = "0.16.0"
 val junitJupiterVersion = "5.10.3"
 val verapdfVersion = "1.26.1"
@@ -58,13 +58,6 @@ tasks {
 repositories {
     mavenCentral()
     mavenLocal()
-    maven {
-        url = uri("https://maven.pkg.github.com/openhtmltopdf/openhtmltopdf")
-        credentials {
-            username = System.getenv("GITHUB_USERNAME")
-            password = System.getenv("GITHUB_PASSWORD")
-        }
-    }
 }
 
 dependencies {
@@ -72,9 +65,9 @@ dependencies {
 
     implementation("com.github.jknack:handlebars:$handlebarsVersion")
     implementation("com.github.jknack:handlebars-jackson2:$handlebarsVersion")
-    implementation("at.datenwort.openhtmltopdf:openhtmltopdf-pdfbox:$openHtmlToPdfVersion")
-    implementation("at.datenwort.openhtmltopdf:openhtmltopdf-slf4j:$openHtmlToPdfVersion")
-    implementation("at.datenwort.openhtmltopdf:openhtmltopdf-svg-support:$openHtmlToPdfVersion")
+    implementation("io.github.openhtmltopdf:openhtmltopdf-pdfbox:$openHtmlToPdfVersion")
+    implementation("io.github.openhtmltopdf:openhtmltopdf-slf4j:$openHtmlToPdfVersion")
+    implementation("io.github.openhtmltopdf:openhtmltopdf-svg-support:$openHtmlToPdfVersion")
 
     implementation("org.jsoup:jsoup:$jsoupVersion")
     implementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")

--- a/src/main/kotlin/no/nav/pdfgen/core/pdf/CreatePdf.kt
+++ b/src/main/kotlin/no/nav/pdfgen/core/pdf/CreatePdf.kt
@@ -53,15 +53,11 @@ fun createPDFA(html: String): ByteArray {
                 PdfRendererBuilder()
                     .apply {
                         for (font in PDFGenCore.environment.fonts) {
-                            // her les vi inn ei ttf-fil frå resources/fonts
-                            val ttf: TrueTypeFont =
-                                TTFParser()
-                                    .parse(
-                                        RandomAccessReadBufferedFile(
+                            val ttf = TTFParser().parse(
+                                RandomAccessReadBufferedFile(
                                             "${PDFGenCore.environment.fontsRoot.path}/${font.path}"
                                         )
-                                    )
-                            ttf.isEnableGsub = false
+                                    ).also { it.isEnableGsub = false }
                             useFont(
                                 PDFontSupplier(PDType0Font.load(PDDocument(), ttf, font.subset)),
                                 font.family,

--- a/src/main/kotlin/no/nav/pdfgen/core/pdf/CreatePdf.kt
+++ b/src/main/kotlin/no/nav/pdfgen/core/pdf/CreatePdf.kt
@@ -63,7 +63,7 @@ fun createPDFA(html: String): ByteArray {
                                     )
                             ttf.isEnableGsub = false
                             useFont(
-                                PDFontSupplier(PDType0Font.load(PDDocument(), ttf, true)),
+                                PDFontSupplier(PDType0Font.load(PDDocument(), ttf, font.subset)),
                                 font.family,
                                 font.weight,
                                 font.style,

--- a/src/main/kotlin/no/nav/pdfgen/core/pdf/CreatePdf.kt
+++ b/src/main/kotlin/no/nav/pdfgen/core/pdf/CreatePdf.kt
@@ -93,7 +93,7 @@ fun createPDFA(imageStream: InputStream, outputStream: OutputStream) {
             dc.addCreator("pdfgen-coree")
             dc.addDate(cal)
 
-            val id = xmp.createAndAddPFAIdentificationSchema()
+            val id = xmp.createAndAddPDFAIdentificationSchema()
             id.part = 2
             id.conformance = "U"
 

--- a/src/test/kotlin/no/nav/pdfgen/HelperTest.kt
+++ b/src/test/kotlin/no/nav/pdfgen/HelperTest.kt
@@ -338,7 +338,6 @@ internal class HelperTest {
         assertEquals("", handlebars.compileInline("{{#any d e f g}}YES{{/any}}").apply(context))
     }
 
-
     @Test
     internal fun `Datetime with seconds formatting should format as Norwegian short date and time with seconds`() {
         val context =


### PR DESCRIPTION
Denne oppdateringa har ikkje vore triviell, ref https://github.com/navikt/pdfgen/pull/176

I https://stackoverflow.com/questions/77302346/missing-ligature-in-font-causing-missing-text-in-pdfbox-3-0 kom det tips om å bruke ein workaround med `ttf.setEnableGsub(false);`, så det er det eg har gjort her.

Det gjorde at testane i pdfgen endeleg køyrde ok også.

Med det kan vi gå opp frå PDFBox 2 til PDFBox 3, og over til nyaste versjon av OpenHTMLToPDF med det samme.

Heng saman med https://github.com/navikt/pdfgen/pull/229