### PR TITLE
Use vera jakarta instead of javax because javax.xml.bind will probabl…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ dependencies {
     implementation("io.prometheus:simpleclient_common:$prometheusVersion")
     implementation("io.prometheus:simpleclient_hotspot:$prometheusVersion")
 
-    implementation("org.verapdf:validation-model:$verapdfVersion")
+    implementation("org.verapdf:validation-model-jakarta:$verapdfVersion")
     implementation("io.github.oshai:kotlin-logging-jvm:$kotlinloggerVersion")
 
     implementation("ch.qos.logback:logback-classic:$logbackVersion")


### PR DESCRIPTION
…y no longer be supported in future releases

This makes it easier to import pdfgen-core without using exclusion for clients that already are on jakarta. 