### PR TITLE
Endre duration for å funke med inc (ved å returnere int)

### DIFF
--- a/src/main/kotlin/no/nav/pdfgen/core/template/Helpers.kt
+++ b/src/main/kotlin/no/nav/pdfgen/core/template/Helpers.kt
@@ -107,7 +107,7 @@ fun registerNavHelpers(
                 ChronoUnit.DAYS.between(
                     LocalDate.from(DateTimeFormatter.ISO_DATE.parse(context)),
                     LocalDate.from(DateTimeFormatter.ISO_DATE.parse(options.param(0))),
-                )
+                ).toInt()
             },
         )
 

--- a/src/test/kotlin/no/nav/pdfgen/HelperTest.kt
+++ b/src/test/kotlin/no/nav/pdfgen/HelperTest.kt
@@ -1637,4 +1637,16 @@ internal class HelperTest {
             "Value1 123123 value3"
         )
     }
+
+
+    @Test
+    internal fun `duration can be incremented with inc`() {
+        val context = jsonContext(jsonNodeFactory.objectNode())
+        assertEquals(
+            "1",
+            handlebars
+                .compileInline("{{inc (duration \"2023-01-01\" \"2023-01-01\")}}")
+                .apply(context),
+        )
+    }
 }


### PR DESCRIPTION
**Problemet:**
I team hag (helse arbeidsgiver) ønsker vi å telle antall dager mellom fom og tom inklusiv.

Om man prøver `{{inc (duration "2023-01-01" "2023-01-01")}}` får man feilen
`java.lang.Long cannot be cast to class java.lang.Integer`

**Løsning:**
Denne endringen får `duration` til å returnere int slik at den kan brukes med `inc` hjelpe funksjonen

Dette gjøres med [toInt()](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-long/to-int.html) som fungerer opp til `MAX_VALUE = 2 147 483 647`